### PR TITLE
Add support for MySQL 5.7

### DIFF
--- a/hlxce/web/includes/class_db.php
+++ b/hlxce/web/includes/class_db.php
@@ -89,6 +89,8 @@ class DB_mysql
 		
 		if ( $this->link )
 		{
+			$q = @mysql_query("SET SESSION sql_mode=''; ");
+			@mysql_free_result($q);
 			$q = @mysql_query("SET NAMES 'utf8'", $this->link);
 			@mysql_free_result($q);
 			if ( $db_name != '' )


### PR DESCRIPTION
Current queries don't support ONLY_FULL_GROUP_BY mode,
which is default for MySQL 5.7

I propose to set empty sql_mode just after connecting to database.
