### PR TITLE
Dockerize php part

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM php:5-apache
+
+RUN apt-get update && apt-get install -y \
+        git \
+        vim \
+        libpng-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng12-dev
+RUN rm -rfv /var/lib/apt/lists/*
+
+COPY php.ini.example /usr/local/etc/php/php.ini
+
+RUN docker-php-ext-configure gd \
+        --enable-gd-native-ttf \
+        --with-freetype-dir=/usr/include/freetype2 \
+        --with-png-dir=/usr/include \
+        --with-jpeg-dir=/usr/include
+RUN docker-php-ext-install gd opcache mysql
+RUN docker-php-ext-enable opcache
+
+RUN mkdir /noxus
+WORKDIR /noxus
+
+COPY . /noxus/
+RUN cp -rv hlxce/web/* /var/www/html/ && chown -R www-data:www-data /var/www/html/

--- a/php.ini.example
+++ b/php.ini.example
@@ -1,0 +1,8 @@
+[PHP]
+date.timezone = Europe/London
+error_log = /proc/self/fd/2
+display_errors = On
+display_startup_errors = On
+log_errors = On
+log_errors_max_len = 1024
+


### PR DESCRIPTION
Well, docker is docker. This changes would allow to create isolated containers of running apache + php stuff automatically from a source tree.

Some of my thoughts about this:
-  Dockerfile itself is a good example of working environment, while hlx dependencies are poorly documented and php5 is dying. Yea, it doesn't work with php7
- Sandboxes and dev/test instances will become easy to deploy
- Dockerfile allows to deploy hlx as a part of docker-compose bundles like [dis one](https://github.com/melkor217/ayanami/blob/master/docker-compose.yml#L40) and do not care about setting up environment still
